### PR TITLE
added check for missing props

### DIFF
--- a/src/containers/MessageThreadContainer.js
+++ b/src/containers/MessageThreadContainer.js
@@ -17,7 +17,7 @@ class MessageThreadContainer extends Component {
 	 * @returns {jsx}
 	 */
 	render() {
-		const messageId = (this.props.match.params.messageId) ? parseInt(this.props.match.params.messageId) : 0;
+		const messageId = (this.props.match && this.props.match.params.messageId) ? parseInt(this.props.match.params.messageId) : 0;
 		const message = this.props.messages[messageId];
 
 		return (


### PR DESCRIPTION
I cannot start your project due to your match prop not existing on the first render.  I added a check to makes sure that it exists before trying to access properties on it.